### PR TITLE
Performing linting of the Role with the GitHub Action

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,16 @@
+---
+# .ansible-lint
+
+exclude_paths:
+  - .github/
+
+use_default_rules: true
+
+skip_list:
+  - yaml  # Violations reported by yamllint.
+
+enable_list:
+  - fqcn-builtins  # Use FQCN for builtin actions.
+
+warn_list:
+  - experimental  # All rules tagged as experimental

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,34 @@
 ---
-name: Ansible Role Test
-on: [push]  # yamllint disable-line rule:truthy
+name: Engineering Ansible Base Role
+
+on: [push, pull_request]  # yamllint disable-line rule:truthy
+
+permissions: read-all
+
+# Reference information about concurrency stategy provided
+# here:
+# https://exercism.org/docs/building/github/gha-best-practices
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
-  Ansible-Role-Test:
-    runs-on: ubuntu-latest
+
+  ansible-lint:
+    timeout-minutes: 5
+    runs-on: ubuntu-22.04
+    steps:
+      # Important: This sets up your GITHUB_WORKSPACE environment variable
+      - uses: actions/checkout@v3
+
+      - name: Lint Yaml
+        uses: frenck/action-yamllint@v1
+
+      - name: Lint Ansible Role
+        uses: ansible-community/ansible-lint-action@v6
+
+  ansible-role-test:
+    timeout-minutes: 5
+    runs-on: ubuntu-22.04
     steps:
       - run: echo "Ansible Test Completed!"

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,34 @@
+---
+
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+
+rules:
+  braces: enable
+  brackets: enable
+  colons: enable
+  commas: enable
+  comments:
+    level: warning
+  comments-indentation:
+    level: warning
+  document-end: disable
+  document-start:
+    level: warning
+  empty-lines: enable
+  empty-values: disable
+  # float-values: disable
+  hyphens: enable
+  indentation: enable
+  key-duplicates: enable
+  key-ordering: disable
+  line-length: enable
+  new-line-at-end-of-file: enable
+  new-lines: enable
+  octal-values: disable
+  quoted-strings: disable
+  trailing-spaces: enable
+  truthy:
+    level: warning

--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ See license.md
 
 ## Author Information
 
+## Running GitHub Actions Locally
+When making changes to the the [GitHub Action](https://github.com/features/actions) in this repository contributors should utilise the [act](https://github.com/nektos/act) tool that enables fast feedback by running actions locally.
+
+### Important Information related to the Yamllint GitHub Action
+The [yamllint action](https://github.com/frenck/action-yamllint) used by the GitHub Action performs a build when not run locally which does not appear to work with `act`. To work around this contributors should perform the following action to build a container for use locally.
+
+```
+docker build \
+  -t act-frenck-action-yamllint-v1-dockeraction:latest \
+  ~/.cache/act/frenck-action-yamllint@v1/src
+```
+**NOTE**: Ensure you use the correct version tag for the action when running this command
+
 ### Useful Information
 
 To run current tests

--- a/tasks/adr_tools.yml
+++ b/tasks/adr_tools.yml
@@ -13,6 +13,7 @@
     url: https://github.com/npryce/adr-tools/archive/refs/tags/{{ adr_tools_version }}.tar.gz
     checksum: "sha256:{{ adr_tools_sha256 }}"
     dest: /tmp
+    mode: 0644
   when: not adr_bin.stat.exists
   tags: adr
 
@@ -25,14 +26,14 @@
   tags: adr
 
 - name: Symlink default adr-tools
-  file:
+  ansible.builtin.file:
     src: "adr-tools-{{ adr_tools_version }}"
     dest: "/opt/adr-tools"
     state: link
   tags: adr
 
 - name: Add adr executable script
-  copy:
+  ansible.builtin.copy:
     src: adr
     dest: /usr/local/bin
     mode: 0755


### PR DESCRIPTION
Incorporated the performing of linting using [yamllint](https://github.com/adrienverge/yamllint) and [ansible-lint](https://ansible-lint.readthedocs.io/en/latest/) into this roles GitHub Action.

Uses the following GitHub actions:
* https://github.com/ansible-community/ansible-lint-action (ansible-lint)
* https://github.com/frenck/action-yamllint (yamllint)

Closes #3 