### PR TITLE
Provide a place to store architectural decisions for this role

### DIFF
--- a/ADR.md
+++ b/ADR.md
@@ -1,0 +1,7 @@
+# Architecture Decision Records
+
+Core decisions for this role are captured here.
+
+* [1. Record architecture decisions](doc/adr/0001-record-architecture-decisions.md)
+
+NB. Do not edit this document as it is auto-generated

--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ A list of other roles hosted on Galaxy should go here, plus any details in regar
 
 See license.md
 
+## Architecture Decision Records
+This role uses Architecture Decision Records (ADR) to capture significant design decisions. If you are new to the concept of ADRs then it is recommended you read [Documenting Architecture Decision](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) by Michael Nygard.
+
+ This role uses a lightweight ADR toolset created by Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools). ADRs for this role are stored under the `doc/adr` folder.
+
+ The ADRs for this role can be found in the [ADR.md](ADR.md) document.
+
+ ### Useful Manual ADR Tool Information
+
+Regenerate the [ADR.md](ADR.md)
+
+```
+adr generate toc -p doc/adr/ -i doc/adr/intro.md -o doc/adr/outro.md
+```
+
 ## Author Information
 
 ## Running GitHub Actions Locally

--- a/doc/adr/0001-record-architecture-decisions.md
+++ b/doc/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2022-09-07
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/doc/adr/intro.md
+++ b/doc/adr/intro.md
@@ -1,0 +1,1 @@
+Core decisions for this role are captured here.

--- a/doc/adr/outro.md
+++ b/doc/adr/outro.md
@@ -1,0 +1,1 @@
+NB. Do not edit this document as it is auto-generated

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,14 +7,14 @@
 
 # Temporary Ansible Role tooling until the Ansible Engineering role is developed
 
-- name: manage temporary tool - yamllint
+- name: Manage temporary tool - yamllint
   become: true
   ansible.builtin.package:
     name: yamllint
     state: "{{ temporary_tooling_state }}"
   tags: temporary_tools
 
-- name: manage temporary tool - ansible_lint
+- name: Manage temporary tool - ansible_lint
   become: true
   ansible.builtin.package:
     name: ansible-lint


### PR DESCRIPTION
Initialized the ADR documentation using the tooling `init` command, creating the ADRs in `doc/adr`

- Documented the ADRs in the `README.md`
- Added an intro and outro placeholder/initial file for use in generation
- Provided a manual generation command in the `README.md` that results in an `ADR.MD` in the root of the role
- The generation command uses a prefix to link to the `doc/adr` folder for the ADRs
- FIX: Correct names to have starting capital letter in tasks/main.yml

Closes #4 