### PR TITLE
Provide GitHub Actions security update checking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+# Set update schedule for GitHub Actions
+version: 2
+
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: daily

--- a/ADR.md
+++ b/ADR.md
@@ -3,5 +3,6 @@
 Core decisions for this role are captured here.
 
 * [1. Record architecture decisions](doc/adr/0001-record-architecture-decisions.md)
+* [2. Keep GitHub actions up to date with dependabot](doc/adr/0002-keep-github-actions-up-to-date-with-dependabot.md)
 
 NB. Do not edit this document as it is auto-generated

--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ This role uses Architecture Decision Records (ADR) to capture significant design
 Regenerate the [ADR.md](ADR.md)
 
 ```
-adr generate toc -p doc/adr/ -i doc/adr/intro.md -o doc/adr/outro.md
+adr generate toc \
+  -p doc/adr/ \
+  -i doc/adr/intro.md \
+  -o doc/adr/outro.md  > ADR.md
 ```
 
 ## Author Information

--- a/doc/adr/0002-keep-github-actions-up-to-date-with-dependabot.md
+++ b/doc/adr/0002-keep-github-actions-up-to-date-with-dependabot.md
@@ -1,0 +1,39 @@
+# 2. Keep GitHub actions up to date with dependabot
+
+Date: 2022-09-08
+
+## Status
+
+Accepted
+
+## Context
+
+Actions are often updated with bug fixes and new features to make automated processes more reliable, faster, and safer. This role would like to benefit from these capabilities.
+
+Dependabot can help ensure that references to actions in a repository's `workflow.yml` file are kept up to date.
+
+## Decision
+
+This role will use [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot) to ensure the action's references the latest versions.
+
+Example `dependabot.yml` file for GitHub Actions
+
+```
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"
+
+```
+
+## Consequences
+
+This role will require a `dependabot.yml` file configured with the `package-ecosystem` specified as `github-actions`. This file should be located in the `.github` directory of the repository.
+
+Dependabot will send a `pull request` that updates the references in the workflow to the latest version, so a contributor will need to review and merge this request.


### PR DESCRIPTION
Provided [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot) configuration for this roles GitHub Actions

- Added the ADR and regenerated the ADR documentation
- Updated the README to correct ADR generation
- Added Dependabot configuration file

Closes #7 