### PR TITLE
Starting using Python packages for appropriate tooling

### DIFF
--- a/ADR.md
+++ b/ADR.md
@@ -3,6 +3,7 @@
 Core decisions for this role are captured here.
 
 * [1. Record architecture decisions](doc/adr/0001-record-architecture-decisions.md)
-* [2. Keep GitHub actions up to date with dependabot](doc/adr/0002-keep-github-actions-up-to-date-with-dependabot.md)
+* [2. Keep GitHub Actions up to date with Dependabot](doc/adr/0002-keep-github-actions-up-to-date-with-dependabot.md)
+* [3. Use Python Packages where appropriate](doc/adr/0003-use-python-packages-were-appropriate.md)
 
 NB. Do not edit this document as it is auto-generated

--- a/README.md
+++ b/README.md
@@ -81,7 +81,12 @@ docker build \
 
 To run current tests
 ```
-ansible-playbook ./tests/test.yml -i tests/inventory --ask-become-pass --become --check --verbose --tags temporary_tools,adr
+ansible-playbook ./tests/test.yml \
+  -i tests/inventory \
+  --ask-become-pass \
+  --check \
+  --verbose \
+  --tags temporary_tools,adr
 ```
 
 #### References

--- a/doc/adr/0002-keep-github-actions-up-to-date-with-dependabot.md
+++ b/doc/adr/0002-keep-github-actions-up-to-date-with-dependabot.md
@@ -1,4 +1,4 @@
-# 2. Keep GitHub actions up to date with dependabot
+# 2. Keep GitHub Actions up to date with Dependabot
 
 Date: 2022-09-08
 

--- a/doc/adr/0003-use-python-packages-were-appropriate.md
+++ b/doc/adr/0003-use-python-packages-were-appropriate.md
@@ -1,0 +1,27 @@
+# 3. Use Python Packages where appropriate
+
+Date: 2022-09-09
+
+## Status
+
+Accepted
+
+## Context
+
+Some tools such as `yamllint` and `ansible-lint` are more commonly installed using Python packages rather than distro packages. Using distro packages often result in older versions of these packages.
+
+These older versions often don't align with the latest versions that other tools using these packages use. This results in differences in versions and behaviours between the local packages and those in GitHub Actions.
+
+When it is more appropriate to use a Python package than a distro package Catosplace engineers should utilise the Python package.
+
+## Decision
+
+Catosplace engineers should utilise the Python packages to install the following packages:
+
+* [yamllint](https://github.com/adrienverge/yamllint)
+
+## Consequences
+
+Catosplace engineers will need to have Python and `pip` available to install these packages. As other tools such as `pre-commit` are also more commonly installed using Python packages, which is a base engineering tool, Python and `pip` should be set up in this base role.
+
+Using the Python packages will enable the development versions of these tools to align with those used by GitHub Actions and other tooling.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,11 +7,24 @@
 
 # Temporary Ansible Role tooling until the Ansible Engineering role is developed
 
-- name: Manage temporary tool - yamllint
+- name: Install Pyhton is Python3
   become: true
   ansible.builtin.package:
+    name: python-is-python3
+    state: present
+  tags: temporary_tools
+
+- name: Install Pip
+  become: true
+  ansible.builtin.package:
+    name: python3-pip
+    state: present
+  tags: temporary_tools
+
+- name: Manage temporary tool - yamllint
+  ansible.builtin.pip:
     name: yamllint
-    state: "{{ temporary_tooling_state }}"
+    state: present
   tags: temporary_tools
 
 - name: Manage temporary tool - ansible_lint


### PR DESCRIPTION
Update the temporary tools to install [yamllint](https://github.com/adrienverge/yamllint) using the Python package.

- Updated `temporary_tools` task to install `yamllint` using Python rather than disto packages
- Documented this use of Python Packages in an ADR
- Regenerated ADR documentation

These changes required Python to be managed and `pip` installed prior to installing the package, these should become part of the base - as future tools in the base will require them.

Closes #14