### PR TITLE
Provide ansible-lint tool via Python package

### DIFF
--- a/doc/adr/0003-use-python-packages-were-appropriate.md
+++ b/doc/adr/0003-use-python-packages-were-appropriate.md
@@ -19,6 +19,7 @@ When it is more appropriate to use a Python package than a distro package Catosp
 Catosplace engineers should utilise the Python packages to install the following packages:
 
 * [yamllint](https://github.com/adrienverge/yamllint)
+* [ansible-lint](https://github.com/ansible/ansible-lint)
 
 ## Consequences
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,25 +11,25 @@
   become: true
   ansible.builtin.package:
     name: python-is-python3
-    state: present
+    state: "{{ temporary_tooling_state }}"
   tags: temporary_tools
 
 - name: Install Pip
   become: true
   ansible.builtin.package:
     name: python3-pip
-    state: present
+    state: "{{ temporary_tooling_state }}"
   tags: temporary_tools
 
 - name: Manage temporary tool - yamllint
   ansible.builtin.pip:
     name: yamllint
-    state: present
+    state: "{{ temporary_tooling_state }}"
   tags: temporary_tools
 
 - name: Manage temporary tool - ansible_lint
   become: true
-  ansible.builtin.package:
+  ansible.builtin.pip:
     name: ansible-lint
     state: "{{ temporary_tooling_state }}"
   tags: temporary_tools


### PR DESCRIPTION
Update `ansible-lint` provisioning to use Python package instead of distro package.

- Updated ADR to include `ansible-lint` for appropriate Python packages.

Closes #15 