### PR TITLE
Provision Python is Python3 and Python Pip3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This [Ansible][1] role is used by Catosplace Engineering team members to install
 
 Current Catosplace Engineering base tooling:
 
+* [Python3 and Python3 Pip](https://www.python.org/downloads/) - Required for several tools used by Catosplace Engineering teams
 * [adr-tools](https://github.com/npryce/adr-tools) - Tool for working with a log of [Architecture Decision Records](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) (ADRs)
 
 Temporary tooling installed at this time until a Catosplace Engineering Ansible role is implemented:
@@ -21,7 +22,6 @@ Temporary tooling installed at this time until a Catosplace Engineering Ansible 
 
 Planned Catosplace Engineering base tooling:
 
-* [Python3 and Python3 Pip](https://www.python.org/downloads/) - Required for several tools used by Catosplace Engineering teams
 * [pre-commit](https://pre-commit.com/) - Tool for managing pre-commit hooks
 Architecture Decision Records
 * [docker](https://docker.com) - Container Runtime

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,25 +1,15 @@
 ---
 # tasks file for Catosplace engineering base tools
 
-- name: Include adr-tools tasks
+- name: Install Python and Pip
+  ansible.builtin.include_tasks: python_pip.yml
+  tags: python_pip
+
+- name: Install adr-tools
   ansible.builtin.include_tasks: adr_tools.yml
   tags: adr
 
 # Temporary Ansible Role tooling until the Ansible Engineering role is developed
-
-- name: Install Pyhton is Python3
-  become: true
-  ansible.builtin.package:
-    name: python-is-python3
-    state: "{{ temporary_tooling_state }}"
-  tags: temporary_tools
-
-- name: Install Pip
-  become: true
-  ansible.builtin.package:
-    name: python3-pip
-    state: "{{ temporary_tooling_state }}"
-  tags: temporary_tools
 
 - name: Manage temporary tool - yamllint
   ansible.builtin.pip:

--- a/tasks/python_pip.yml
+++ b/tasks/python_pip.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Install Pyhton is Python3
+  become: true
+  ansible.builtin.package:
+    name: python-is-python3
+    state: present
+  tags: python_pip
+
+- name: Install Pip
+  become: true
+  ansible.builtin.package:
+    name: python3-pip
+    state: present
+  tags: python_pip


### PR DESCRIPTION
Created a new task file for include.

This task file provisions Python is Python3 and Python Pip3 to enable use of Python to install tooling.

Closes #32 