### PR TITLE
Provision pre-commit tooling with role

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This [Ansible][1] role is used by Catosplace Engineering team members to install
 Current Catosplace Engineering base tooling:
 
 * [Python3 and Python3 Pip](https://www.python.org/downloads/) - Required for several tools used by Catosplace Engineering teams
+* [pre-commit](https://pre-commit.com/) - Tool for managing pre-commit hooks
 * [adr-tools](https://github.com/npryce/adr-tools) - Tool for working with a log of [Architecture Decision Records](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) (ADRs)
 
 Temporary tooling installed at this time until a Catosplace Engineering Ansible role is implemented:
@@ -22,8 +23,6 @@ Temporary tooling installed at this time until a Catosplace Engineering Ansible 
 
 Planned Catosplace Engineering base tooling:
 
-* [pre-commit](https://pre-commit.com/) - Tool for managing pre-commit hooks
-Architecture Decision Records
 * [docker](https://docker.com) - Container Runtime
 * [docker-compose](https://docs.docker.com/compose/) - Used to run multi-container Docker applications
 * [git](https://git-scm.com/) - Distributed version control
@@ -45,7 +44,7 @@ Each of the core tools installed will have an installation path, version and pot
 | adr_tools_install_path | no | /opt/adr-tools | | adr-tools Installation Path
 | adr_tools_version       | no       | 3.0.0        |                 | Version of ADR Tools                          |
 | adr_tools_sha256 | no | SHA for 3.0.0 | | SHA for ADR Tools
-
+| pre_commit_version | no | 2.20.0 | | Version of pre-commit required |
 ## Example Playbook
 
 Simple Playbook
@@ -129,7 +128,7 @@ ansible-playbook ./tests/test.yml \
   --ask-become-pass \
   --check \
   --verbose \
-  --tags temporary_tools,adr
+  --tags adr,temporary_tools,pre-commit,python_pip
 ```
 
 **Ansible Galaxy Role Id**

--- a/doc/adr/0003-use-python-packages-were-appropriate.md
+++ b/doc/adr/0003-use-python-packages-were-appropriate.md
@@ -18,6 +18,7 @@ When it is more appropriate to use a Python package than a distro package Catosp
 
 Catosplace engineers should utilise the Python packages to install the following packages:
 
+* [pre-commit](https://pre-commit.com/)
 * [yamllint](https://github.com/adrienverge/yamllint)
 * [ansible-lint](https://github.com/ansible/ansible-lint)
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,12 @@
   ansible.builtin.include_tasks: python_pip.yml
   tags: python_pip
 
+- name: Install pre-commit {{ pre_commit_version | default('2.20.0') }}
+  ansible.builtin.pip:
+    name: pre-commit=={{ pre_commit_version | default('2.20.0') }}
+    state: present
+  tags: pre-commit
+
 - name: Install adr-tools
   ansible.builtin.include_tasks: adr_tools.yml
   tags: adr

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,3 +11,8 @@ temporary_tooling_state: present
 adr_tools_version: 3.0.0
 # yamllint disable-line rule:line-length
 adr_tools_sha256: 9490f31a457c253c4113313ed6352efcbf8f924970a309a08488833b9c325d7c
+
+## pre-commit
+
+# pre-commit version
+# pre_commit_version: 2.20.0


### PR DESCRIPTION
Add task to provision [pre-commit](https://pre-commit.com/) within this role.

- Documented the installation in the role
- Added a `pre_commit_version` variable - defaulted to 2.20.0
- Updated ADR about pip installation

Closes #30 