### PR TITLE
provide Ansible Galaxy import information and tips

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,23 @@
+# GitHub Workflows
+
+This folder contains the GitHub Workflows to lint and test the Ansible role. It also contains a release workflow that imports the role to [Ansible Galaxy](https://galaxy.ansible.com/).
+
+## Ansible Galaxy Import
+The import utilises this GitHub action https://github.com/robertdebock/galaxy-action which requires the setting of the `git_branch` parameter as it defaults to `master` and the Catosplace Ansible Galaxy API Key provided as a secret.
+
+Importing of the role manually can be done using the following command
+```
+ansible-galaxy role import \
+  --token <TOKEN>
+  --branch main \
+  --role-name catosplace/engineering_base \
+    catosplace \
+    ansible-engineering-base-role
+```
+The `token` is the API Key, and note the use of the `branch` parameter to the command.
+
+### Finding the Ansible Galaxy Role Id
+The Ansible Galaxy badges used by this repository require the Ansible Galaxy Role id. The following command can be used to find this:
+```
+ansible-galaxy info catosplace.engineering_base | grep -E 'id: [0-9]' | awk {'print $2'}
+```

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ act \
   -s galaxy_api_key=<GALAXY_API_KEY>
 ```
 
+More information about importing this role to Ansible Galaxy can be found [here](.github/README.md#ansible-galaxy-import).
+
 #### References
 
 * [CyVerse Ansible Role Template](https://github.com/CyVerse-Ansible/ansible-role-template)


### PR DESCRIPTION
Added an additional README in the `.github` folder about the GitHub actions including the Galaxy release capabilities

- Linked to this README from the main README
- Provided information on getting the Ansbile Galaxy Role Id

Closes: #21 